### PR TITLE
Fix for python 3.10

### DIFF
--- a/skfusion/fusion/base/fusion_graph.py
+++ b/skfusion/fusion/base/fusion_graph.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from collections import defaultdict, OrderedDict, Iterable
+from collections import defaultdict, OrderedDict
+from collections.abc import Iterable
 from uuid import uuid1 as uuid
 from numbers import Number
 


### PR DESCRIPTION
`collections.Iterable` has been deprecated since python 3.10, and it has been moved to `collections.abc.Iterable`